### PR TITLE
Fix logging error in webhook handler

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,7 +61,7 @@ def handle_webhook():
 
     elif request.method == 'POST':
         data = request.json
-        logger.info("Evento recibido:", data)
+        logger.info("Evento recibido: %s", data)
 
         try:
             for entry in data.get('entry', []):


### PR DESCRIPTION
## Summary
- correct logger usage for incoming Instagram events
- ensure final newline in `app.py`

## Testing
- `python -m py_compile app.py 'app copy.py'`

------
https://chatgpt.com/codex/tasks/task_e_68644f89ea80832ca93d66c8b102a90d