### PR TITLE
Fix UI navigation and initialize auto reply controls

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -61,12 +61,50 @@ document.addEventListener("DOMContentLoaded", function () {
       document.querySelectorAll(".tab-content").forEach((content) => content.classList.remove("active"));
       
       // Usar dataset para obtener el tab (corrección principal)
-      const tab = button.dataset.tab; 
+      const tab = button.dataset.tab;
       button.classList.add("active");
       document.getElementById(tab).classList.add("active");
     });
   });
+
+  // Al iniciar, ocultar/mostrar campos según estado del toggle
+  toggleRuleFields(document.getElementById("autoToggle")?.checked);
 });
+
+function showScreen(screenId) {
+  document.querySelectorAll(".screen").forEach((screen) => screen.classList.remove("active"));
+  const target = document.getElementById(screenId);
+  if (target) {
+    target.classList.add("active");
+  }
+}
+
+function toggleRuleFields(enabled) {
+  ["ruleKeyword", "ruleResponses", "saveNewRuleBtn"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.disabled = !enabled;
+  });
+}
+
+function initializeAutoToggle() {
+  const toggle = document.getElementById("autoToggle");
+  if (!toggle) return;
+  toggle.addEventListener("change", async () => {
+    const post_id = document.getElementById("rulePostId").value.trim();
+    const enabled = toggle.checked;
+    toggleRuleFields(enabled);
+    if (!post_id) return;
+    try {
+      await fetch("/api/set_auto", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ post_id, enabled }),
+      });
+    } catch (e) {
+      console.error("Error actualizando auto", e);
+    }
+  });
+}
 
 // Cargar publicaciones del usuario
 async function loadUserPosts(page = 1) {
@@ -124,6 +162,7 @@ async function loadPostDetails(post_id) {
     
     if (data.status === "success") {
       const post = data.post;
+      showScreen("screen-details");
       responderContainer.innerHTML = `
         <h2>Detalles del Post</h2>
         <img id="detailThumbnail" src="${post.thumbnail || "/static/images/placeholder.jpg"}" width="100%" height="200" onerror="this.src='/static/images/placeholder.jpg'" />
@@ -173,6 +212,9 @@ async function loadPostDetails(post_id) {
           });
         }
       }
+
+      await loadAllRules(post_id);
+      await loadAllRulesForTest(post_id);
     }
   } catch (err) {
     responderContainer.innerHTML = `<p class="error">Error de conexión: ${err.message}</p>`;


### PR DESCRIPTION
## Summary
- implement `showScreen`, `toggleRuleFields` and `initializeAutoToggle` helpers
- ensure post details screen is shown when selecting a post
- refresh rule lists when loading post details

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_686d2898e184832cacb415ff61ec493e