### PR TITLE
Improve rule management with local fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Excluir archivos sensibles
 .env
 logs/
-__pycache__/
-*.pyc
+__pycache__/*.pyc

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -464,6 +464,17 @@ header p {
     border-radius: 8px;
     margin-bottom: 10px;
 }
+.keyword-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.delete-rule-btn {
+    background: none;
+    border: none;
+    color: #dc3545;
+    cursor: pointer;
+}
 .keyword-rule ul {
     margin-top: 10px;
     padding-left: 20px;
@@ -480,5 +491,4 @@ header p {
 }
 .tab-btn.active {
     color: #3897f0;
-    border-bottom: 2px solid #3897f0;
-}
+    border-bottom: 2px solid #3897f0;}


### PR DESCRIPTION
## Summary
- add local fallback when adding or deleting rules
- show keywords with delete buttons in the UI
- style keyword list for column layout
- only respond to comments when auto mode is enabled and log API errors

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_686d2898e184832cacb415ff61ec493e