### PR TITLE
Improve replies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Excluir archivos sensibles
 .env
 logs/
-__pycache__/
-*.pyc
+__pycache__/*.pyc
+venv/

--- a/app.py
+++ b/app.py
@@ -68,30 +68,66 @@ def handle_webhook():
                 for change in entry.get('changes', []):
                     value = change.get('value', {})
                     comment_text = value.get('text', '').lower()
-                    post_id = value.get('media_id', '') or value.get('post_id', '')
+                    post_id = (
+                        value.get('media_id')
+                        or value.get('post_id')
+                        or (value.get('media') or {}).get('id')
+                        or (value.get('post') or {}).get('id')
+                        or ''
+                    )
+                    comment_id = (
+                        value.get('comment_id')
+                        or value.get('id')
+                        or (value.get('comment') or {}).get('id')
+                    )
+                    comment_time = value.get('timestamp') or value.get('created_time')
                     from_user = value.get('from', {})  # Aquí se define from_user
 
-                    if not post_id or not comment_text:
+                    # Evitar responder a nuestros propios comentarios
+                    try:
+                        if str(from_user.get('id')) == str(IG_USER_ID):
+                            continue
+                    except Exception:
+                        pass
+
+                    if not post_id or not comment_id or not comment_text:
+                        continue
+
+                    # Ignorar si ya respondimos a este comentario
+                    if has_responded(comment_id):
                         continue
 
                     config = load_config_for_post(post_id)
+
+                    if not config.get("enabled", False):
+                        logger.info("Auto respuesta desactivada para %s", post_id)
+                        continue
+
+                    enabled_since = config.get("enabled_since")
+                    if enabled_since and comment_time:
+                        try:
+                            ct = datetime.fromisoformat(comment_time.replace('Z','+00:00'))
+                            es = datetime.fromisoformat(enabled_since)
+                            if ct < es:
+                                continue
+                        except Exception:
+                            pass
+
                     matched = False
 
                     # Buscar coincidencias con palabras clave
                     for keyword, responses in config.get('keywords', {}).items():
                         if keyword.lower() in comment_text:
                             reply_text = random.choice(responses) if isinstance(responses, list) and len(responses) > 0 else responses[0]
-                            send_instagram_comment(post_id, reply_text)
-                            log_activity(comment_text, post_id, reply_text, from_user=from_user, matched=True)
+                            send_comment_reply(comment_id, reply_text)
+                            log_activity(comment_id, comment_text, post_id, reply_text, from_user=from_user, matched=True)
                             matched = True
                             break
 
                     # Si no hay match, usar respuesta predeterminada
+                    # Si no hay coincidencia, no responder
                     if not matched:
-                        default_response = config.get('default_response', '')
-                        if default_response:
-                            send_instagram_comment(post_id, default_response)
-                            log_activity(comment_text, post_id, default_response, from_user=from_user, matched=False)
+                        logger.info("Sin palabra clave en %s, se omite respuesta", comment_id)
 
             return jsonify({"status": "success", "message": "Evento procesado"}), 200
 
@@ -101,52 +137,74 @@ def handle_webhook():
 
 
 def load_config_for_post(post_id):
-    """Carga configuración específica para un post desde Firebase"""
+    """Carga configuración específica para un post desde Firebase o archivo local"""
     try:
         ref = db.reference(f'posts/{post_id}')
         config = ref.get()
-        if config is None:
-            return {
-                "keywords": {},
-                "default_response": "Gracias por tu comentario 😊",
-                "enabled": False,
-            }
-
-        if "enabled" not in config:
-            config["enabled"] = False
-        return config
     except Exception as e:
         logger.error(f"Error cargando configuración desde Firebase: {str(e)}")
-        return {
-            "keywords": {},
-            "default_response": "Gracias por tu comentario 😊",
-            "enabled": False,
-        }
+        config = None
+
+    if config is None:
+        # Intentar cargar desde archivo local
+        try:
+            with open(get_config_path(post_id)) as f:
+                config = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError) as ex:
+            logger.error(f"Error leyendo configuración local: {ex}")
+            config = {
+                "keywords": {},
+                "default_response": "",
+                "enabled": False,
+                "enabled_since": None,
+            }
+
+    if "enabled" not in config:
+        config["enabled"] = False
+    if "enabled_since" not in config:
+        config["enabled_since"] = None
+    return config
 
 
 def save_config_for_post(post_id, config):
-    """Guarda configuración por post en Firebase"""
+    """Guarda configuración por post en Firebase, con fallback local"""
+    success = False
     try:
         ref = db.reference(f'posts/{post_id}')
         ref.set(config)
-        return True
+        success = True
     except Exception as e:
         logger.error(f"Error guardando en Firebase: {str(e)}")
-        return False
+
+    if not success:
+        try:
+            with open(get_config_path(post_id), 'w') as f:
+                json.dump(config, f, indent=2)
+            success = True
+        except Exception as ex:
+            logger.error(f"Error guardando configuración local: {ex}")
+    return success
 
 
-def send_instagram_comment(media_id, message):
-    """Enviar comentario vía Graph API"""
-    url = f"{GRAPH_URL}/{media_id}/comments"
+def send_comment_reply(comment_id, message):
+    """Responder a un comentario vía Graph API"""
+    url = f"{GRAPH_URL}/{comment_id}/replies"
     payload = {
-        'message': message,
-        'access_token': ACCESS_TOKEN
+        "message": message,
+        "access_token": ACCESS_TOKEN,
     }
-    response = requests.post(url, data=payload, timeout=30)
-    return response.json()
+    try:
+        response = requests.post(url, data=payload, timeout=30)
+        data = response.json()
+        if "error" in data:
+            logger.error("Error enviando respuesta: %s", data["error"].get("message"))
+        return data
+    except Exception as e:
+        logger.error("Excepción enviando respuesta: %s", e)
+        return {"error": str(e)}
 
 
-def log_activity(comment_text, media_id, reply_text, from_user, matched=True):
+def log_activity(comment_id, comment_text, media_id, reply_text, from_user, matched=True):
     """Registrar actividad globalmente"""
     try:
         with open(HISTORY_FILE) as f:
@@ -155,7 +213,8 @@ def log_activity(comment_text, media_id, reply_text, from_user, matched=True):
         main_config = {"responded_comments": {}}
 
     timestamp = datetime.now().isoformat()
-    comment_id = f"{media_id}_{timestamp}"
+    if not comment_id:
+        comment_id = f"{media_id}_{timestamp}"
 
     main_config['responded_comments'][comment_id] = {
         "usuario": from_user.get('username', 'anonimo'),
@@ -167,6 +226,16 @@ def log_activity(comment_text, media_id, reply_text, from_user, matched=True):
 
     with open(HISTORY_FILE, 'w') as f:
         json.dump(main_config, f, indent=2)
+
+
+def has_responded(comment_id):
+    """Verifica si ya se respondió a un comentario"""
+    try:
+        with open(HISTORY_FILE) as f:
+            main_config = json.load(f)
+        return comment_id in main_config.get('responded_comments', {})
+    except (FileNotFoundError, json.JSONDecodeError):
+        return False
 
 
 @app.route('/api/get_posts', methods=['GET'])
@@ -313,9 +382,8 @@ def add_new_keyword_rule():
         if not post_id or not keyword or not responses:
             return jsonify({"status": "error", "message": "Faltan datos"}), 400
 
-        # Cargar configuración actual desde Firebase
-        ref = db.reference(f'posts/{post_id}')
-        config = ref.get() or {"keywords": {}, "default_response": "Gracias por tu comentario"}
+        # Cargar configuración actual (Firebase o local)
+        config = load_config_for_post(post_id)
 
         # Procesar respuestas
         if isinstance(responses, list):
@@ -329,13 +397,10 @@ def add_new_keyword_rule():
             return jsonify({"status": "error", "message": "Máximo 7 respuestas por palabra clave"}), 400
 
         # Actualizar configuración
-        config["keywords"][keyword] = response_list
-        ref.update({
-            "keywords": config["keywords"],
-            "default_response": config.get("default_response", "Gracias por tu comentario")
-        })
-
-        return jsonify({"status": "success", "message": "Regla agregada correctamente"})
+        config.setdefault("keywords", {})[keyword] = response_list
+        if save_config_for_post(post_id, config):
+            return jsonify({"status": "success", "message": "Regla agregada correctamente"})
+        return jsonify({"status": "error", "message": "No se pudo guardar"}), 500
     except Exception as e:
         logger.error(f"Error al agregar regla: {str(e)}")
         return jsonify({"status": "error", "message": str(e)}), 500
@@ -349,10 +414,13 @@ def delete_keyword_rule():
         if not post_id or not keyword:
             return jsonify({"status": "error", "message": "Datos incompletos"}), 400
 
-        ref = db.reference(f'posts/{post_id}/keywords/{keyword}')
-        ref.delete()
-
-        return jsonify({"status": "success", "message": "Palabra clave eliminada"})
+        config = load_config_for_post(post_id)
+        if keyword in config.get("keywords", {}):
+            del config["keywords"][keyword]
+            if save_config_for_post(post_id, config):
+                return jsonify({"status": "success", "message": "Palabra clave eliminada"})
+            return jsonify({"status": "error", "message": "No se pudo guardar"}), 500
+        return jsonify({"status": "error", "message": "Palabra clave no encontrada"}), 404
     except Exception as e:
         logger.error(f"Error borrando regla: {str(e)}")
         return jsonify({"status": "error", "message": str(e)}), 500
@@ -367,12 +435,35 @@ def set_auto_reply():
         enabled = data.get('enabled')
         if post_id is None or enabled is None:
             return jsonify({"status": "error", "message": "Faltan datos"}), 400
+        success = False
+        timestamp = datetime.utcnow().isoformat()
+        try:
+            ref = db.reference(f'posts/{post_id}')
+            current = ref.get() or {}
+            update = {"enabled": bool(enabled)}
+            if enabled:
+                update["enabled_since"] = timestamp
+            ref.update(update)
+            success = True
+        except Exception as e:
+            logger.error(f"Error actualizando en Firebase: {str(e)}")
 
-        ref = db.reference(f'posts/{post_id}')
-        current = ref.get() or {}
-        ref.update({"enabled": bool(enabled)})
+        if not success:
+            try:
+                path = get_config_path(post_id)
+                config = load_config_for_post(post_id)
+                config["enabled"] = bool(enabled)
+                if enabled:
+                    config["enabled_since"] = timestamp
+                with open(path, 'w') as f:
+                    json.dump(config, f, indent=2)
+                success = True
+            except Exception as ex:
+                logger.error(f"Error guardando configuración local: {ex}")
 
-        return jsonify({"status": "success", "enabled": bool(enabled)})
+        if success:
+            return jsonify({"status": "success", "enabled": bool(enabled)})
+        return jsonify({"status": "error", "message": "No se pudo actualizar"}), 500
     except Exception as e:
         logger.error(f"Error actualizando auto respuesta: {str(e)}")
         return jsonify({"status": "error", "message": str(e)}), 500
@@ -380,21 +471,31 @@ def set_auto_reply():
 
 @app.route('/api/list_rules', methods=['GET'])
 def list_all_rules():
+    rules = {}
     try:
         ref = db.reference('posts')
         rules = ref.get() or {}
-        result = []
-        for post_id, config in rules.items():
-            if isinstance(config, dict):
-                result.append({
-                    "post_id": post_id,
-                    "keywords": config.get("keywords", {}),
-                    "default_response": config.get("default_response", "")
-                })
-        return jsonify({"status": "success", "rules": result})
     except Exception as e:
-        logger.error(f"Error listando reglas: {str(e)}")
-        return jsonify({"status": "error", "message": str(e)}), 500
+        logger.error(f"Error listando reglas desde Firebase: {str(e)}")
+        # Fallback: cargar reglas desde archivos locales
+        for path in glob(os.path.join(CONFIG_DIR, 'config_*.json')):
+            try:
+                with open(path) as f:
+                    cfg = json.load(f)
+                post_id = os.path.splitext(os.path.basename(path))[0].replace('config_', '')
+                rules[post_id] = cfg
+            except Exception as ex:
+                logger.error(f"Error leyendo {path}: {ex}")
+
+    result = []
+    for post_id, config in rules.items():
+        if isinstance(config, dict):
+            result.append({
+                "post_id": post_id,
+                "keywords": config.get("keywords", {}),
+                "default_response": config.get("default_response", "")
+            })
+    return jsonify({"status": "success", "rules": result})
 
 
 @app.route('/api/get_history', methods=['GET'])
@@ -434,16 +535,13 @@ def process_comments_manually():
         for keyword, responses in config.get('keywords', {}).items():
             if keyword.lower() in comment_text:
                 reply_text = random.choice(responses) if isinstance(responses, list) and len(responses) > 0 else responses[0]
-                log_activity(comment_text, post_id, reply_text, {"username": "test_user"}, matched=True)
+                log_activity(None, comment_text, post_id, reply_text, {"username": "test_user"}, matched=True)
                 matched = True
                 break
 
-        # Si no hay palabra clave, usar default_response
+        # Si no hay palabra clave, no se genera respuesta
         if not matched:
-            default_response = config.get('default_response', '')
-            if default_response:
-                reply_text = default_response
-                log_activity(comment_text, post_id, reply_text, {"username": "test_user"}, matched=False)
+            reply_text = ""
 
         return jsonify({
             "status": "success",

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "keywords": {},
   "default_response": "",
+  "dm_message": "",
   "responded_comments": {
     "17895695668004550_2025-06-11T10:49:03.123456": {
       "usuario": "usuario_prueba",
@@ -8,5 +9,4 @@
       "respuesta": "Gracias por tu comentario",
       "fecha": "2025-06-11T10:49:03.123456",
       "matched": false
-    }
-  }}
+    }  }}

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "keywords": {},
-  "default_response": "Gracias por tu comentario",
+  "default_response": "",
   "responded_comments": {
     "17895695668004550_2025-06-11T10:49:03.123456": {
       "usuario": "usuario_prueba",
@@ -9,5 +9,4 @@
       "fecha": "2025-06-11T10:49:03.123456",
       "matched": false
     }
-  }
-}
+  }}

--- a/config_17861827212350635.json
+++ b/config_17861827212350635.json
@@ -9,4 +9,4 @@
     ]
   },
   "default_response": "",
-  "responded_comments": {}}
+  "dm_message": "",  "responded_comments": {}}

--- a/config_17861827212350635.json
+++ b/config_17861827212350635.json
@@ -8,6 +8,5 @@
       "Hola!!"
     ]
   },
-  "default_response": "Gracias por tu comentario",
-  "responded_comments": {}
-}
+  "default_response": "",
+  "responded_comments": {}}

--- a/config_18040193132625647.json
+++ b/config_18040193132625647.json
@@ -4,4 +4,5 @@
       "Hola! Bienvenida a mio perfil y gracias por el comentario!"
     ]
   },
-  "default_response": ""}
+  "default_response": "",
+  "dm_message": ""

--- a/config_18040193132625647.json
+++ b/config_18040193132625647.json
@@ -4,5 +4,4 @@
       "Hola! Bienvenida a mio perfil y gracias por el comentario!"
     ]
   },
-  "default_response": "Gracias por tu comentario"
-}
+  "default_response": ""}

--- a/config_18455062186076216.json
+++ b/config_18455062186076216.json
@@ -4,4 +4,5 @@
       "Hola! Bienvenida a mio perfil y gracias por el comentario!"
     ]
   },
-  "default_response": ""}
+  "default_response": "",
+  "dm_message": ""

--- a/config_18455062186076216.json
+++ b/config_18455062186076216.json
@@ -4,5 +4,4 @@
       "Hola! Bienvenida a mio perfil y gracias por el comentario!"
     ]
   },
-  "default_response": "Gracias por tu comentario"
-}
+  "default_response": ""}

--- a/config_posts/config_18035068796343906.json
+++ b/config_posts/config_18035068796343906.json
@@ -7,5 +7,4 @@
       "Perfecto. Ya tenes el link en DM."
     ]
   },
-  "default_response": "Gracias por tu comentario \ud83d\ude0a"
-}
+  "default_response": ""}

--- a/config_posts/config_18035068796343906.json
+++ b/config_posts/config_18035068796343906.json
@@ -7,4 +7,5 @@
       "Perfecto. Ya tenes el link en DM."
     ]
   },
-  "default_response": ""}
+  "default_response": "",
+  "dm_message": ""

--- a/config_posts/config_18040193132625647.json
+++ b/config_posts/config_18040193132625647.json
@@ -4,4 +4,5 @@
       "Hola!Gracias por tu comentario!"
     ]
   },
-  "default_response": ""}
+  "default_response": "",
+  "dm_message": ""

--- a/config_posts/config_18040193132625647.json
+++ b/config_posts/config_18040193132625647.json
@@ -4,5 +4,4 @@
       "Hola!Gracias por tu comentario!"
     ]
   },
-  "default_response": "Gracias por tu comentario"
-}
+  "default_response": ""}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -464,6 +464,17 @@ header p {
     border-radius: 8px;
     margin-bottom: 10px;
 }
+.keyword-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.delete-rule-btn {
+    background: none;
+    border: none;
+    color: #dc3545;
+    cursor: pointer;
+}
 .keyword-rule ul {
     margin-top: 10px;
     padding-left: 20px;
@@ -480,5 +491,4 @@ header p {
 }
 .tab-btn.active {
     color: #3897f0;
-    border-bottom: 2px solid #3897f0;
-}
+    border-bottom: 2px solid #3897f0;}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -47,6 +47,13 @@ document.addEventListener("DOMContentLoaded", function () {
     saveKeywordForPost(post_id, keyword, responses);
   });
 
+  document.getElementById("saveDmMessageBtn")?.addEventListener("click", () => {
+    const post_id = document.getElementById("rulePostId").value.trim();
+    const dm_message = document.getElementById("dmMessage").value.trim();
+    if (!post_id) return;
+    saveDmMessage(post_id, dm_message);
+  });
+
   // Mostrar política de privacidad
   document.getElementById("privacyBtn")?.addEventListener("click", () => {
     showScreen("screen-privacy");
@@ -89,7 +96,13 @@ function showScreen(screenId) {
 }
 
 function toggleRuleFields(enabled) {
-  ["ruleKeyword", "ruleResponses", "saveNewRuleBtn"].forEach((id) => {
+  [
+    "ruleKeyword",
+    "ruleResponses",
+    "saveNewRuleBtn",
+    "dmMessage",
+    "saveDmMessageBtn",
+  ].forEach((id) => {
     const el = document.getElementById(id);
     if (el) el.disabled = !enabled;
   });
@@ -189,6 +202,10 @@ async function loadPostDetails(post_id) {
       if (autoToggle) {
         autoToggle.checked = post.enabled || false;
         toggleRuleFields(autoToggle.checked);
+      }
+
+      if (document.getElementById("dmMessage")) {
+        document.getElementById("dmMessage").value = post.dm_message || "";
       }
       
       // Asignar ID del post a los campos de prueba
@@ -421,5 +438,27 @@ async function loadAllRulesForTest(post_id = null) {
     }
   } catch (err) {
     container.innerHTML = `<p class="error">Error de conexión: ${err.message}</p>`;
+  }
+}
+
+// Guardar mensaje directo
+async function saveDmMessage(post_id, dm_message) {
+  const statusBox = document.getElementById("dmStatusBox");
+  statusBox.innerHTML = '<p><i class="fas fa-spinner fa-spin"></i> Guardando mensaje...</p>';
+  try {
+    const res = await fetch("/api/set_dm", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ post_id, dm_message }),
+    });
+    const result = await res.json();
+    if (result.status === "success") {
+      statusBox.innerHTML = '<p class="success"><i class="fas fa-check-circle"></i> Mensaje guardado</p>';
+      setTimeout(() => (statusBox.innerHTML = ""), 3000);
+    } else {
+      statusBox.innerHTML = `<p class="error">Error: ${result.message}</p>`;
+    }
+  } catch (err) {
+    statusBox.innerHTML = `<p class="error">Error de conexión: ${err.message}</p>`;
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,6 +98,16 @@
                                         ></textarea>
                                         <button id="saveNewRuleBtn" class="btn-primary">Guardar Regla</button>
                                         <div id="newRuleStatusBox" class="status-box"></div>
+
+                                        <label for="dmMessage">Mensaje por DM</label>
+                                        <textarea
+                                                id="dmMessage"
+                                                rows="2"
+                                                placeholder="Escribe el mensaje directo"
+                                        ></textarea>
+                                        <button id="saveDmMessageBtn" class="btn-primary">Guardar Mensaje DM</button>
+                                        <div id="dmStatusBox" class="status-box"></div>
+
                                         <div id="configRulesListContainer"></div>
                                 </div>
 


### PR DESCRIPTION
## Summary
- detect comment IDs and store `enabled_since`
- reply directly to new comments only once
- ignore local venv folder
- ignore self replies
- skip default responses when no keyword found

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`
- `python app.py` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_686d2898e184832cacb415ff61ec493e