### PR TITLE
Display user IDs in comment list

### DIFF
--- a/app.py
+++ b/app.py
@@ -332,7 +332,7 @@ def get_post_comments(post_id):
         params = {
             'access_token': ACCESS_TOKEN,
             'limit': 100,
-            'fields': 'text,from{username},timestamp'
+            'fields': 'text,from{id,username},timestamp'
         }
 
         comments = []
@@ -350,6 +350,7 @@ def get_post_comments(post_id):
                     "id": c.get('id', ''),
                     "text": c.get('text', 'Comentario no disponible'),
                     "username": user.get('username', 'usuario_anonimo'),
+                    "user_id": user.get('id', ''),
                     "timestamp": c.get('timestamp', '')
                 })
 

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -233,7 +233,7 @@ async function loadPostDetails(post_id) {
             const commentDiv = document.createElement("div");
             commentDiv.className = "comment-item";
             commentDiv.innerHTML = `
-              <strong>${comment.username}</strong>: "${comment.text}"
+              <strong>${comment.username} (${comment.user_id})</strong>: "${comment.text}"
               <small>${new Date(comment.timestamp).toLocaleString()}</small>
             `;
             commentsList.appendChild(commentDiv);


### PR DESCRIPTION
## Summary
- include user ID when retrieving post comments
- show user ID next to username in comments

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686e9367e4dc832c896972a19495f003