### PR TITLE
Display user IDs in comment list

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -233,7 +233,7 @@ async function loadPostDetails(post_id) {
             const commentDiv = document.createElement("div");
             commentDiv.className = "comment-item";
             commentDiv.innerHTML = `
-              <strong>${comment.username}</strong>: "${comment.text}"
+              <strong>${comment.username} (${comment.user_id} - ${comment.id})</strong>: "${comment.text}"
               <small>${new Date(comment.timestamp).toLocaleString()}</small>
             `;
             commentsList.appendChild(commentDiv);


### PR DESCRIPTION
## Summary
- include user ID when retrieving post comments
- show user ID and comment ID in comment list
- send DM on keyword match

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686e9367e4dc832c896972a19495f003