### PR TITLE
Enhance UI and add delayed messaging

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import os
 import json
 import logging
 import time
+import threading
 import requests
 from datetime import datetime
 import random
@@ -37,6 +38,17 @@ if not firebase_admin._apps:
         logger.error(f"No se pudo conectar a Firebase: {str(e)}")
 
 os.makedirs(CONFIG_DIR, exist_ok=True)
+
+def schedule_action(delay, func, *args, **kwargs):
+    """Ejecuta una función después de cierto delay sin bloquear el flujo"""
+    def _run():
+        time.sleep(delay)
+        try:
+            func(*args, **kwargs)
+        except Exception as e:
+            logger.error(f"Error en acción diferida: {str(e)}")
+
+    threading.Thread(target=_run, daemon=True).start()
 
 def get_config_path(post_id):
     return os.path.join(CONFIG_DIR, f"config_{post_id}.json")
@@ -115,7 +127,17 @@ def handle_webhook():
                     for keyword, responses in config.get('keywords', {}).items():
                         if keyword.lower() in comment_text:
                             reply_text = random.choice(responses) if isinstance(responses, list) and responses else responses
-                            send_comment_reply(comment_id, reply_text)
+                            schedule_action(10, send_comment_reply, comment_id, reply_text)
+                            dm_text = config.get('dm_message')
+                            if dm_text and from_user.get('id'):
+                                schedule_action(
+                                    20,
+                                    send_direct_message,
+                                    from_user['id'],
+                                    dm_text,
+                                    config.get('dm_button_text'),
+                                    config.get('dm_button_url'),
+                                )
                             matched = True
                             break  # Solo procesar primera coincidencia
 
@@ -155,12 +177,49 @@ def send_comment_reply(comment_id, text):
         logger.error(f"Excepción al responder comentario: {str(e)}")
         return {"error": str(e)}
 
+def send_direct_message(user_id, text, button_text=None, button_url=None):
+    """Envía un mensaje directo utilizando la API de Instagram"""
+    url = f"{GRAPH_URL}/{IG_USER_ID}/messages"
+    headers = {
+        "Authorization": f"Bearer {ACCESS_TOKEN}",
+        "Content-Type": "application/json"
+    }
+    payload = {"recipient": {"id": user_id}}
+    if button_text and button_url:
+        payload["message"] = {
+            "attachment": {
+                "type": "template",
+                "payload": {
+                    "template_type": "button",
+                    "text": text,
+                    "buttons": [
+                        {"type": "web_url", "url": button_url, "title": button_text}
+                    ],
+                },
+            }
+        }
+    else:
+        payload["message"] = {"text": text}
+
+    try:
+        response = requests.post(url, headers=headers, json=payload, timeout=10)
+        data = response.json()
+        if "error" in data:
+            logger.error(f"Error enviando DM: {data['error']['message']}")
+            return {"error": data['error']['message']}
+        return data
+    except Exception as e:
+        logger.error(f"Excepción enviando DM: {str(e)}")
+        return {"error": str(e)}
+
 def load_config_for_post(post_id):
     """Carga configuración específica para un post"""
     config = {
         "keywords": {},
         "default_response": "",
         "dm_message": "",
+        "dm_button_text": "",
+        "dm_button_url": "",
         "enabled": False,
         "enabled_since": None,
     }
@@ -316,7 +375,9 @@ def get_post_details(post_id):
                 "timestamp": data.get('timestamp', ''),
                 "thumbnail": data.get('thumbnail_url', data.get('media_url', '/static/images/placeholder.jpg')),
                 "enabled": config.get('enabled', False),
-                "dm_message": config.get('dm_message', '')
+                "dm_message": config.get('dm_message', ''),
+                "dm_button_text": config.get('dm_button_text', ''),
+                "dm_button_url": config.get('dm_button_url', '')
             }
         })
 
@@ -332,7 +393,7 @@ def get_post_comments(post_id):
         params = {
             'access_token': ACCESS_TOKEN,
             'limit': 100,
-            'fields': 'text,from{username},timestamp'
+            'fields': 'text,from{id,username},timestamp'
         }
 
         comments = []
@@ -350,6 +411,7 @@ def get_post_comments(post_id):
                     "id": c.get('id', ''),
                     "text": c.get('text', 'Comentario no disponible'),
                     "username": user.get('username', 'usuario_anonimo'),
+                    "user_id": user.get('id', ''),
                     "timestamp": c.get('timestamp', '')
                 })
 
@@ -501,12 +563,16 @@ def set_dm_message():
         data = request.get_json()
         post_id = data.get('post_id')
         dm_message = data.get('dm_message')
+        button_text = data.get('button_text')
+        button_url = data.get('button_url')
         
         if not post_id:
             return jsonify({"status": "error", "message": "Missing post_id"}), 400
 
         config = load_config_for_post(post_id)
         config['dm_message'] = dm_message
+        config['dm_button_text'] = button_text
+        config['dm_button_url'] = button_url
 
         if save_config_for_post(post_id, config):
             return jsonify({"status": "success", "message": "DM message updated"})

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -492,3 +492,35 @@ header p {
 .tab-btn.active {
     color: #3897f0;
     border-bottom: 2px solid #3897f0;}
+
+.chip-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-bottom: 10px;
+}
+
+.chip {
+    background: #e9ecef;
+    padding: 5px 10px;
+    border-radius: 15px;
+    display: flex;
+    align-items: center;
+}
+.chip button {
+    border: none;
+    background: none;
+    margin-left: 5px;
+    cursor: pointer;
+    color: #dc3545;
+}
+
+.emoji-bar {
+    margin: 5px 0;
+    cursor: pointer;
+    user-select: none;
+}
+.emoji-bar span {
+    padding: 0 4px;
+    font-size: 1.2em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -89,13 +89,13 @@
                                                 </label>
                                         </div>
                                         <label for="ruleKeyword">Palabra Clave</label>
-                                        <input type="text" id="ruleKeyword" placeholder="Ejemplo: hola" />
-                                        <label for="ruleResponses">Respuestas (máximo 7)</label>
-                                        <textarea
-                                                id="ruleResponses"
-                                                rows="4"
-                                                placeholder="Respuesta 1, Respuesta 2,..."
-                                        ></textarea>
+                                        <input type="text" id="ruleKeyword" placeholder="Escribe y presiona Enter" />
+                                        <div class="emoji-bar" data-target="ruleKeyword"><span>😀</span><span>😂</span><span>😍</span><span>👍</span><span>🎉</span><span>🙏</span><span>🔥</span><span>❤️</span></div>
+                                        <div id="keywordList" class="chip-container"></div>
+                                        <label for="ruleResponseInput">Respuestas (máx. 7)</label>
+                                        <input type="text" id="ruleResponseInput" placeholder="Escribe y presiona Enter" />
+                                        <div class="emoji-bar" data-target="ruleResponseInput"><span>😀</span><span>😂</span><span>😍</span><span>👍</span><span>🎉</span><span>🙏</span><span>🔥</span><span>❤️</span></div>
+                                        <div id="responseList" class="chip-container"></div>
                                         <button id="saveNewRuleBtn" class="btn-primary">Guardar Regla</button>
                                         <div id="newRuleStatusBox" class="status-box"></div>
 
@@ -105,6 +105,16 @@
                                                 rows="2"
                                                 placeholder="Escribe el mensaje directo"
                                         ></textarea>
+                                        <div class="emoji-bar" data-target="dmMessage">
+                                                <span>😀</span><span>😂</span><span>😍</span><span>👍</span><span>🎉</span><span>🙏</span><span>🔥</span><span>❤️</span>
+                                        </div>
+                                        <label for="dmButtonText">Texto del botón</label>
+                                        <input type="text" id="dmButtonText" placeholder="Texto del botón" />
+                                        <div class="emoji-bar" data-target="dmButtonText">
+                                                <span>😀</span><span>😂</span><span>😍</span><span>👍</span><span>🎉</span><span>🙏</span><span>🔥</span><span>❤️</span>
+                                        </div>
+                                        <label for="dmButtonUrl">Enlace del botón</label>
+                                        <input type="text" id="dmButtonUrl" placeholder="https://..." />
                                         <button id="saveDmMessageBtn" class="btn-primary">Guardar Mensaje DM</button>
                                         <div id="dmStatusBox" class="status-box"></div>
 
@@ -119,16 +129,16 @@
 				<div id="reglas" class="tab-content">
 					<h2>Gestión de Palabras Clave</h2>
 					<div class="form-group">
-						<label for="ruleKeyword">Palabra Clave</label>
-						<input type="text" id="globalRuleKeyword" placeholder="Ejemplo: hola" />
+                                                <label for="ruleKeyword">Palabra Clave</label>
+                                                <input type="text" id="globalRuleKeyword" placeholder="Escribe y presiona Enter" />
+                                                <div class="emoji-bar" data-target="globalRuleKeyword"><span>😀</span><span>😂</span><span>😍</span><span>👍</span><span>🎉</span><span>🙏</span><span>🔥</span><span>❤️</span></div>
+                                                <div id="globalKeywordList" class="chip-container"></div>
 					</div>
 					<div class="form-group">
-						<label for="globalRuleResponses">Respuestas (máx. 7)</label>
-						<textarea
-							id="globalRuleResponses"
-							rows="4"
-							placeholder="Respuesta 1, Respuesta 2,..."
-						></textarea>
+                                                <label for="globalRuleResponses">Respuestas (máx. 7)</label>
+                                                <input type="text" id="globalRuleResponseInput" placeholder="Escribe y presiona Enter" />
+                                                <div class="emoji-bar" data-target="globalRuleResponseInput"><span>😀</span><span>😂</span><span>😍</span><span>👍</span><span>🎉</span><span>🙏</span><span>🔥</span><span>❤️</span></div>
+                                                <div id="globalResponseList" class="chip-container"></div>
 					</div>
 					<button id="globalSaveRuleBtn" class="btn-primary">Guardar Regla</button>
 					<div id="globalRuleStatusBox" class="status-box"></div>


### PR DESCRIPTION
## Summary
- schedule delayed actions for replies and DMs
- support DM buttons via new config fields
- create emoji bars and chip lists for keywords and responses
- update frontend to manage lists and DM button settings

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686e9367e4dc832c896972a19495f003