### PR TITLE
Fix DM function duplication and repeated reply logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,11 +139,6 @@ def handle_webhook():
                                     config.get('dm_button_url'),
                                 )
 
-                            send_comment_reply(comment_id, reply_text)
-                            dm_text = config.get('dm_message')
-                            if dm_text and from_user.get('id'):
-                                send_direct_message(from_user['id'], dm_text)
-
                             matched = True
                             break  # Solo procesar primera coincidencia
 
@@ -184,7 +179,6 @@ def send_comment_reply(comment_id, text):
         return {"error": str(e)}
 
 def send_direct_message(user_id, text, button_text=None, button_url=None):
-def send_direct_message(user_id, text):
     """Envía un mensaje directo utilizando la API de Instagram"""
     url = f"{GRAPH_URL}/{IG_USER_ID}/messages"
     headers = {
@@ -207,10 +201,6 @@ def send_direct_message(user_id, text):
         }
     else:
         payload["message"] = {"text": text}
-    payload = {
-        "recipient": {"id": user_id},
-        "message": {"text": text}
-    }
 
     try:
         response = requests.post(url, headers=headers, json=payload, timeout=10)


### PR DESCRIPTION
## Summary
- remove duplicate `send_direct_message` definition
- avoid overwriting DM payload
- remove extra direct reply calls after scheduling actions

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686face3fad4832c8ebad8a61d42e424