### PR TITLE
Add legal, privacy and unsubscribe pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,18 @@ def get_config_path(post_id):
 def home():
     return render_template('index.html')
 
+@app.route('/privacy')
+def privacy_page():
+    return render_template('privacy.html')
+
+@app.route('/legal')
+def legal_page():
+    return render_template('legal.html')
+
+@app.route('/unsubscribe')
+def unsubscribe_page():
+    return render_template('unsubscribe.html')
+
 @app.route('/webhook', methods=['GET', 'POST'])
 def handle_webhook():
     if request.method == 'GET':

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -524,3 +524,16 @@ header p {
     padding: 0 4px;
     font-size: 1.2em;
 }
+
+.menu {
+    display: flex;
+    gap: 15px;
+    justify-content: center;
+    padding: 10px;
+    background: #f5f5f5;
+}
+.menu a {
+    color: #3897f0;
+    text-decoration: none;
+    font-weight: 600;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,10 +39,15 @@
 			</div>
 			<!-- Pantalla principal -->
 			<div id="screen-home" class="screen active">
-				<header>
-					<h1><i class="fas fa-robot"></i> Instagram Bot</h1>
-					<p>Selecciona una publicación para ver más detalles</p>
-				</header>
+                                <header>
+                                        <h1><i class="fas fa-robot"></i> Instagram Bot</h1>
+                                        <p>Selecciona una publicación para ver más detalles</p>
+                                </header>
+                                <nav class="menu">
+                                        <a href="/privacy">Política de Privacidad</a>
+                                        <a href="/legal">Aviso Legal</a>
+                                        <a href="/unsubscribe">Formulario de Baja</a>
+                                </nav>
 
 				<div id="postSelectorContainer" class="post-grid">
 					<p>

--- a/templates/legal.html
+++ b/templates/legal.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Aviso Legal</title>
+</head>
+<body>
+    <h1>Aviso Legal</h1>
+
+    <p>Este sitio web y la aplicación asociada pertenecen a:</p>
+
+    <ul>
+        <li><strong>Nombre completo o razón social:</strong> Juan Pérez / MiApp S.A.</li>
+        <li><strong>Domicilio:</strong> Calle Falsa 123, Ciudad, Argentina</li>
+        <li><strong>Correo electrónico:</strong> contacto@miapp.com</li>
+        <li><strong>Teléfono:</strong> +54 9 11 1234-5678</li>
+    </ul>
+
+    <h2>Propiedad Intelectual:</h2>
+    <p>Todo el contenido, diseño, código y marcas comerciales son propiedad exclusiva del titular, salvo que se indique lo contrario.</p>
+
+    <h2>Exención de responsabilidad:</h2>
+    <p>La Aplicación se ofrece "tal cual". No nos hacemos responsables de errores en la automatización, cambios en las APIs de Facebook/Instagram, o uso indebido por parte de terceros.</p>
+</body>
+</html>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Política de Privacidad</title>
+</head>
+<body>
+    <h1>Política de Privacidad</h1>
+
+    <p>Esta Política de Privacidad explica cómo recopilamos, usamos y protegemos los datos personales de los usuarios cuando interactúan con nuestra aplicación (“la Aplicación”), que automatiza respuestas a comentarios y mensajes directos en redes sociales como Facebook e Instagram.</p>
+
+    <h2>Información que recopilamos:</h2>
+    <ul>
+        <li><strong>Comentarios públicos:</strong> Solo se analizan comentarios públicos realizados en publicaciones de páginas conectadas a la Aplicación.</li>
+        <li><strong>Nombres de usuario y perfiles públicos:</strong> Se recopila el nombre de usuario y foto de perfil del autor del comentario para personalizar la interacción.</li>
+        <li><strong>Mensajes enviados y recibidos:</strong> La Aplicación puede enviar mensajes directos automáticos al autor del comentario, según las reglas configuradas por el administrador de la página.</li>
+    </ul>
+
+    <h2>¿Cómo se usa esta información?</h2>
+    <p>Los datos se utilizan únicamente para:</p>
+    <ul>
+        <li>Identificar palabras clave en comentarios públicos.</li>
+        <li>Responder automáticamente a comentarios y enviar mensajes privados personalizados.</li>
+        <li>Medir el rendimiento básico de las interacciones automatizadas (opcional).</li>
+    </ul>
+
+    <h2>¿Con quién compartimos estos datos?</h2>
+    <p>No compartimos ni vendemos datos personales a terceros. La Aplicación no almacena ni procesa conversaciones privadas ni información sensible.</p>
+
+    <h2>Tus derechos:</h2>
+    <p>Tienes derecho a:</p>
+    <ul>
+        <li>Solicitar acceso a tus datos.</li>
+        <li>Solicitar la eliminación de tus datos.</li>
+        <li>Revocar el contacto automático en cualquier momento.</li>
+    </ul>
+
+    <p>Puedes contactarnos en: <a href="mailto:tu-email@dominio.com">tu-email@dominio.com</a></p>
+</body>
+</html>

--- a/templates/unsubscribe.html
+++ b/templates/unsubscribe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Formulario de Baja</title>
+</head>
+<body>
+    <h1>Formulario de Baja de Contacto Automático</h1>
+
+    <form action="#" method="POST">
+        <label for="nombre">Nombre completo (opcional):</label><br>
+        <input type="text" id="nombre" name="nombre"><br><br>
+
+        <label for="email">Correo electrónico o nombre de usuario:</label><br>
+        <input type="text" id="email" name="email" required><br><br>
+
+        <label>Motivo de la baja (opcional):</label><br>
+        <input type="checkbox" id="no-deseo" name="motivo" value="No deseo recibir más mensajes">
+        <label for="no-deseo">No deseo recibir más mensajes</label><br>
+
+        <input type="checkbox" id="no-solicitado" name="motivo" value="Recibí mensajes no solicitados">
+        <label for="no-solicitado">Recibí mensajes no solicitados</label><br>
+
+        <input type="checkbox" id="otro" name="motivo" value="Otro motivo">
+        <label for="otro">Otro motivo:</label>
+        <input type="text" name="otro-motivo"><br><br>
+
+        <button type="submit">Enviar</button>
+    </form>
+
+    <p>Gracias por tu tiempo. Tu solicitud será procesada dentro de las próximas 24 horas.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide /privacy, /legal and /unsubscribe routes
- add navigation menu linking to the new pages
- style the new menu
- add HTML templates for Privacy Policy, Legal Notice and Unsubscribe form

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686fca7d4bc8832c846896d69b85476e