### PR TITLE
Display comment replies under post

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -422,6 +422,27 @@ header p {
     border-left: 3px solid #3897f0;
 }
 
+.btn-toggle-replies {
+    background: none;
+    border: none;
+    color: #3897f0;
+    cursor: pointer;
+    margin-top: 5px;
+}
+
+.replies-container {
+    margin-top: 10px;
+    margin-left: 20px;
+}
+
+.reply-item {
+    padding: 8px;
+    margin-bottom: 8px;
+    background: #fff;
+    border-left: 3px solid #ccc;
+    border-radius: 5px;
+}
+
 .comment-item:last-child {
     margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- include `comment_count` when fetching comments
- add endpoint to list replies for a comment
- show a toggle to fetch and display replies below each comment
- style replies and toggle button

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686fd38c2c90832c95557db8f7c7d388