### PR TITLE
Improve Firebase setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Example environment variables for the Instagram bot
+INSTAGRAM_ACCESS_TOKEN=YOUR_INSTAGRAM_ACCESS_TOKEN
+INSTAGRAM_USER_ID=YOUR_IG_USER_ID
+WEBHOOK_VERIFY_TOKEN=YOUR_WEBHOOK_TOKEN
+
+# Firebase service account credentials (JSON string or path)
+FIREBASE_SERVICE_ACCOUNT_JSON=
+FIREBASE_CREDENTIALS_PATH=
+FIREBASE_DATABASE_URL=https://your-project.firebaseio.com
+
+# Firebase client SDK config for the frontend
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_PROJECT_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_APP_ID=
+
+# Optional: application port
+PORT=5000

--- a/app.py
+++ b/app.py
@@ -32,21 +32,25 @@ HISTORY_FILE = "config_global.json"
 
 # Inicializar Firebase
 def init_firebase():
-    """Inicializa Firebase utilizando credenciales de variables de entorno."""
+    """Inicializa Firebase utilizando únicamente variables de entorno."""
     if firebase_admin._apps:
         return
     try:
         cred_json = os.getenv('FIREBASE_SERVICE_ACCOUNT_JSON')
+        cred_path = os.getenv('FIREBASE_CREDENTIALS_PATH')
         if cred_json:
             cred_info = json.loads(cred_json)
             cred = credentials.Certificate(cred_info)
-        else:
-            cred_path = os.getenv('FIREBASE_CREDENTIALS_PATH', 'firebase_credentials.json')
+        elif cred_path:
             cred = credentials.Certificate(cred_path)
+        else:
+            raise ValueError('FIREBASE_SERVICE_ACCOUNT_JSON or FIREBASE_CREDENTIALS_PATH must be set')
 
-        firebase_admin.initialize_app(cred, {
-            'databaseURL': os.getenv('FIREBASE_DATABASE_URL')
-        })
+        db_url = os.getenv('FIREBASE_DATABASE_URL')
+        if not db_url:
+            raise ValueError('FIREBASE_DATABASE_URL not set')
+
+        firebase_admin.initialize_app(cred, {'databaseURL': db_url})
     except Exception as e:
         logger.error(f"No se pudo conectar a Firebase: {str(e)}")
 


### PR DESCRIPTION
## Summary
- refactor `init_firebase` to only read credentials and database URL from env vars
- provide `.env.example` template for required variables

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687018644008832ca02f12ea1860c6ab